### PR TITLE
Set dependencies for MJML 4.8+ compatibility

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -7,6 +7,14 @@ export default class MjMsoButton extends BodyComponent {
 
   static endingTag = true
 
+  static dependencies = {
+    // Tell the validator which tags are allowed as our component's parent
+    'mj-hero': ['mj-msobutton'],
+    'mj-column': ['mj-msobutton'],
+    // Tell the validator which tags are allowed as our component's children
+    'mj-msobutton': []
+  }
+
   static allowedAttributes = {
     align: 'enum(left,center,right)',
     'background-color': 'color',


### PR DESCRIPTION
Now it's impossible to use mjml-msobutton with MJML 4.8+ because of lack of dependencies registered.  
PR in the boilerplate component repo that changed this behavior: https://github.com/mjmlio/mjml-component-boilerplate/pull/35 (and also [comments on this commit](https://github.com/mjmlio/mjml-component-boilerplate/commit/4ad1882cec7a3543403ea17b0acf24b2a0a74ae9))

I added dependencies in needed format - this allows to use `mj-msobutton` tag in mjml templates with fresh MJML versions. If needed, I can add more tags where button can be placed - but for now this list looks sufficient to me.