### PR TITLE
Fix broken non-VML buttons in email clients other than MS Outlook

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -213,7 +213,7 @@ export default class MjMsoButton extends BodyComponent {
     const mso = this.getAttribute('mso-proof')
     return `
       ${mso ? this.renderMSO() : ''}
-      ${mso ? '<!--[if !mso]>' : ''}
+      ${mso ? '<!--[if !mso]><!---->' : ''}
       <table
         ${this.htmlAttributes({
           border: '0',


### PR DESCRIPTION
Now there is a huge problem - buttons generated with `mso-proof="true"` attribute are not rendered in email clients other than MS Outlook.  
I think this is because no email clients are aware of "comments" that are visible only by MS Outlook and such comments:  
`<!--[if mso]>` or `<!--[if !mso]>`  
are interpreted as non-closed, so all subsequent strings are ignored up to this comment: `<![endif]-->`

Suggested simple change uses this peculiarity to render buttons correctly on most email clients. Some examples:

| Without comment | With empty comment |
|-------------------------|---------------------|
| **Gmail** (there is white text from VML buttons, HTML button indents are broken) | |
| ![image](https://user-images.githubusercontent.com/14791483/214008351-cea90793-6568-4845-9a46-27a887071999.png) | ![image](https://user-images.githubusercontent.com/14791483/214008870-2d47a9f4-50fb-4184-b002-2b0cd23b792d.png) |
| **Outlook Web App 2019** (there is white text from VML buttons, HTML button indents are broken) | |
| ![image](https://user-images.githubusercontent.com/14791483/214013718-6310e443-f04b-4d5d-ac1f-d45b757484c7.png) | ![image](https://user-images.githubusercontent.com/14791483/214013803-edc5a8c5-6b8c-4959-8268-dfbe664722cb.png) |
| **Thunderbird** (buttons are just not rendered) | |
| ![image](https://user-images.githubusercontent.com/14791483/214009516-aa9d38c1-87bb-46c5-be7e-a5b64f11a59d.png) | ![image](https://user-images.githubusercontent.com/14791483/214009581-2a1f5f0e-6c87-4add-b7ab-2c322cbce12f.png) |
| **Yandex** (buttons are just not rendered) | |
| ![image](https://user-images.githubusercontent.com/14791483/214009861-22540ebf-338b-4e6c-9668-c7551d63e667.png) | ![image](https://user-images.githubusercontent.com/14791483/214009937-ffffac72-6cab-4146-b8b4-99ca5435b151.png) |
| **Yahoo!** (buttons are neither visible nor clickable) | Buttons are still not visible (white text) but clickable |
| ![image](https://user-images.githubusercontent.com/14791483/214011019-728582f7-7d43-4e0e-ac22-86c2cfe6d65d.png) | ![image](https://user-images.githubusercontent.com/14791483/214011085-45da5c90-6982-4a8f-8651-e67cd80af61f.png) |
| **Gmail for Android** (there is white text from VML buttons, HTML button indents are broken) | |
| ![image](https://user-images.githubusercontent.com/14791483/214012171-825322c9-aa5b-4a8d-83cd-24fdfa178891.png) | ![image](https://user-images.githubusercontent.com/14791483/214012242-0173f556-9e61-4062-a51a-589f32add823.png) |
| **Aqua Mail for Android** (there is white text from VML buttons, HTML button indents are broken) | Some buttons are still not displayed but other problems solved |
| ![image](https://user-images.githubusercontent.com/14791483/214012632-2006b83e-0898-4c4e-a82d-cbd6a910a7f6.png) |  ![image](https://user-images.githubusercontent.com/14791483/214012783-61ea37a3-3e07-4fae-aab4-0840fc4c244e.png) |

This change does not affect desktop MS Outlook rendering at all.

**P.S.** Later I will fix indentation problem with VML buttons in desktop MS Outlook (in separate MR). I see the reason but I still need to do some experiments on it.

**P.P.S.** Fix fore the indentation problem: https://github.com/adrien-zinger/mjml-mso-button/pull/4