### PR TITLE
Fixed indents in VML buttons

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -178,32 +178,44 @@ export default class MjMsoButton extends BodyComponent {
     }
     return `
     <!--[if mso]>
-      <tr>
-        <td ${this.htmlAttributes({
-          align: this.getAttribute('align'),
-        })}>
-          <v:roundrect
-            xmlns:v="urn:schemas-microsoft-com:vml"
-            xmlns:w="urn:schemas-microsoft-com:office:word"
-            ${this.htmlAttributes({
-              href: this.getAttribute('href'),
-              arcsize,
-              fill: bgColor === undefined ? 'f' : 't',
-              strokeweight: stroked ? borderAttr[0] : '0pt',
-              strokecolor: borderAttr[2],
-              stroked: stroked ? 't' : 'f',
-              style: 'msocontainer',
-            })}
-            >
-            ${stroked ? `<v:stroke dashstyle="${borderAttr[1]}" />` : ''}
-            ${bgColor === undefined ? '' : `<v:fill type="tile" color="${bgColor}" />`}
-            <w:anchorlock/>
-            <center ${this.htmlAttributes({ style: 'msobutton' })}>
-              ${this.getContent()}
-            </center>
-          </v:roundrect>
-        </td>
-      </tr>
+      <table
+        ${this.htmlAttributes({
+          border: '0',
+          cellpadding: '0',
+          cellspacing: '0',
+          role: 'presentation',
+          style: 'table',
+        })}
+      >
+        <tbody>
+          <tr>
+            <td ${this.htmlAttributes({
+              align: this.getAttribute('align'),
+            })}>
+              <v:roundrect
+                xmlns:v="urn:schemas-microsoft-com:vml"
+                xmlns:w="urn:schemas-microsoft-com:office:word"
+                ${this.htmlAttributes({
+                  href: this.getAttribute('href'),
+                  arcsize,
+                  fill: bgColor === undefined ? 'f' : 't',
+                  strokeweight: stroked ? borderAttr[0] : '0pt',
+                  strokecolor: borderAttr[2],
+                  stroked: stroked ? 't' : 'f',
+                  style: 'msocontainer',
+                })}
+                >
+                ${stroked ? `<v:stroke dashstyle="${borderAttr[1]}" />` : ''}
+                ${bgColor === undefined ? '' : `<v:fill type="tile" color="${bgColor}" />`}
+                <w:anchorlock/>
+                <center ${this.htmlAttributes({ style: 'msobutton' })}>
+                  ${this.getContent()}
+                </center>
+              </v:roundrect>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     <![endif]-->
     `
   }


### PR DESCRIPTION
VML buttons are rendered with wrong indents at the moment.  
I wrapped `mj-msobutton` component into `<table>` element from [original `mj-button` component](https://github.com/mjmlio/mjml/blob/85bc58e9e2a88cef7424dc2fce3d889f66fb4298/packages/mjml-button/src/index.js#L127-L136) to fix this behavior:

| Before (Outlook 2019) | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/14791483/214040360-dc642f61-e0aa-4285-9dff-422388f8ca47.png) | ![image](https://user-images.githubusercontent.com/14791483/214040415-7893e6ad-2bf9-41d5-b3c3-a70025854009.png) |

Real diff is just adding `<table ...><tbody>...</tbody></table>` and indenting everything inside of it.

Now VML buttons are positioned the same way as buttons in other email clients.  
This fix does not affect rendering of the buttons in other email clients.