### PR TITLE
Possibility to use gradients in VML fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # mjml-msobutton
 
-This component can be usefull if you want to try an outlook proof adventure.
+This component can be useful if you want to try an outlook proof adventure.
 The msobutton has exactly the same behaviours of the classic button but add three more attributes.
 - mso-proof: boolean *(default false)*
 - mso-width: px *(200px)*
 - mso-height: px *(40px)*
 
 More important, these 3 new attributes allow mjml to generate a bulletproof button with radius and stroke as you can see [here](https://buttons.cm/), including the alignment.
+
+`msobutton` supports basic CSS gradients, like these:
+- `linear-gradient(90deg, #AABBCC 0%, #DDEEFF 100%)`
+- `radial-gradient(50% 50%, #AABBCC 0%, #DDEEFF 100%)`
 
 ## Install
 


### PR DESCRIPTION
Previous pull requests were just bug fixes but this one is a feature :)

I added method that transforms basic CSS gradients into VML gradients so even more complex buttons could look more neat in Outlook.

Here is an example:
![image](https://user-images.githubusercontent.com/14791483/214304629-1a209d66-8ded-4b0f-9a0b-1b9f82710a8e.png)

This feature can produce merge conflict with https://github.com/adrien-zinger/mjml-mso-button/pull/4 so I can rebase one of this branches on top of master after any of them will be merged.

This is a last fix I was missing so much in this beautiful component :)