### PR TITLE
Add required % sign to VML ArcSize attribute

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -195,6 +195,7 @@ export default class MjMsoButton extends BodyComponent {
     let arcsize = 0
     if (radii > height) arcsize = 100
     if (radii !== 0 && arcsize !== 100) arcsize = (radii / height) * 100
+    arcsize = `${arcsize}%`;
 
     let borderAttr = ['0pt', 'Solid', '#000000']
     const borderstyleAdapter = {


### PR DESCRIPTION
The ArcSize [should be](https://learn.microsoft.com/en-us/windows/win32/vml/msdn-online-vml-arcsize-attribute) specified using the fraction data type (float or %), otherwise the button radius value won't be translated correctly into VML. Fixed in this PR